### PR TITLE
fix: use secure location service

### DIFF
--- a/src/components/SubscriptionForm.tsx
+++ b/src/components/SubscriptionForm.tsx
@@ -23,15 +23,16 @@ const SubscriptionForm: React.FC<SubscriptionFormProps> = ({
 	const [sessionStartTime] = useState<number>(Date.now())
 
 	// Определяем местоположение пользователя
-	const getLocation = async (): Promise<string> => {
-		try {
-			const res = await fetch('http://ip-api.com/json/')
-			const data = await res.json()
-			return data.city || 'Неизвестный город'
-		} catch (error) {
-			return 'Ошибка определения локации'
-		}
-	}
+        const getLocation = async (): Promise<string> => {
+                try {
+                        const res = await fetch('https://ipapi.co/json/')
+                        if (!res.ok) throw new Error('Location request failed')
+                        const data = await res.json()
+                        return data.city || 'Неизвестный город'
+                } catch (error) {
+                        return 'Ошибка определения локации'
+                }
+        }
 
 	// Проверка, прошло ли больше минуты с последней отправки
 	const canSendPhone = (): boolean => {


### PR DESCRIPTION
## Summary
- use HTTPS API for user location lookup

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897044a08588327aa48071234f23543